### PR TITLE
Update dockerfile and README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.4-alpine
 
 WORKDIR /app
 ADD requirements.txt /app/
@@ -8,3 +8,5 @@ USER app
 
 ENV PATH "/app:$PATH"
 ADD . /app/
+ENTRYPOINT ["sublist3r.py"]
+CMD ["-h"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Sublist3r is a python tool designed to enumerate subdomains of websites using OS
 ```
 git clone https://github.com/aboul3la/Sublist3r.git
 ```
+For docker installation:
+```
+docker build -t aboul3la/sublist3r .
+```
 
 ## Recommended Python Version:
 


### PR DESCRIPTION
This PR adds the following:
1- Changed the base image to `3.4-alpine` as i think it would be better to stick with the supported python version as documented in the `README` file to avoid future syntax changes
2- Added an `Entrypoint` to the docker image which will print the help of `sublist3r` by default
3- Updated the `README` file with how to build the image